### PR TITLE
feature-v2: custom-table 

### DIFF
--- a/projects/mia-lib/src/lib/components/custom-table/custom-table-abstract.directive.ts
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table-abstract.directive.ts
@@ -1,40 +1,11 @@
-import { Directive, Input } from '@angular/core';
+import { ContentChild, Directive, Input, TemplateRef } from '@angular/core';
 
-type TableColumn<T> = keyof T | string; // some cases when a static column is not an attribute of the entity (eg: action, ...)
+@Directive({
+  selector: 'custom-column'
+})
 
-@Directive()
-export abstract class CustomTableAbstractDirective<T> {
+export class TableColumnDirective {
 
-  _columns!: TableColumn<T>[]; // columns need to be displayed; corresponding with entity's property
-  dynamicColumns: TableColumn<T>[] = [];
-
-  // setter for columns to refresh the other columns attribute
-
-  @Input() set columns(columns: TableColumn<T>[]) {
-    this._columns = columns;
-    this.updateColumns();
-  }
-
-  protected constructor(protected staticColumns?: TableColumn<T>[]) {
-    this.updateColumns();
-  }
-
-  updateColumns(): void {
-    if (this._columns && this.staticColumns) {
-      this.dynamicColumns = this.getDynamicColumns(this._columns, this.staticColumns);
-    }
-  }
-
-  private getDynamicColumns(columns: TableColumn<T>[], staticColumns: TableColumn<T>[]): TableColumn<T>[] {
-    const dynamicColumns: TableColumn<T>[] = [];
-
-    for (const column of columns) {
-      //  if the column is not in the static list, add it to the dynamic list
-      if (staticColumns.indexOf(column) === -1) {
-        dynamicColumns.push(column);
-      }
-    }
-
-    return dynamicColumns;
-  }
+  @Input() columnName: string;
+  @ContentChild(TemplateRef) public columnTemplate: TemplateRef<any>;
 }

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.component.html
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.component.html
@@ -44,9 +44,10 @@
   </div>
 
   <!-- Pagination -->
-  <mat-paginator
-    *ngIf="pageable"
-    [pageSizeOptions]="pageSizeOptions"
-    [showFirstLastButtons]="showFirstLastButtons"
-  ></mat-paginator>
+  <div *ngIf="pageable" [class.custom-pagination]="pageable">
+    <mat-paginator
+      [pageSizeOptions]="pageSizeOptions"
+      [showFirstLastButtons]="showFirstLastButtons"
+    ></mat-paginator>
+  </div>
 </main>

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.component.html
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.component.html
@@ -12,19 +12,27 @@
       [matSortDirection]="defaultSortDirection"
     >
       <ng-container
-        *ngFor="let column of dynamicColumns"
-        [matColumnDef]="column"
+        *ngFor="let column of columns; let idx = index"
+        [matColumnDef]="column?.key"
       >
         <mat-header-cell *matHeaderCellDef mat-sort-header disableClear>
-          <span class="truncate-cell">{{ column | uppercase }}</span>
+          <span class="truncate-cell">
+            {{ column?.header || column?.key | uppercase }}
+          </span>
         </mat-header-cell>
-        <mat-cell *matCellDef="let data">
-          <span class="truncate-cell">{{ data[column] }}</span>
+        <mat-cell *matCellDef="let row; let idx = index">
+          <ng-container
+            [ngTemplateOutlet]="columnTemplates[column?.key] || noTemplates"
+            [ngTemplateOutletContext]="{ $implicit: row }"
+          ></ng-container>
+          <ng-template #noTemplates>
+            <span class="truncate-cell">{{ row[column.key] }}</span>
+          </ng-template>
         </mat-cell>
       </ng-container>
 
-      <mat-header-row *matHeaderRowDef="_columns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: _columns"></mat-row>
+      <mat-header-row *matHeaderRowDef="displayColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayColumns"></mat-row>
 
       <!-- Loading spinner -->
       <div *matNoDataRow>

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.component.scss
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.component.scss
@@ -48,7 +48,7 @@ $-bd-radius: calc($-unit-px * 3);
   }
 }
 
-.mat-paginator-container {
+.custom-pagination {
   border    : 1px solid palette.$shade;
   border-top: none;
 

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.component.ts
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.component.ts
@@ -1,7 +1,7 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   AfterViewInit, Component, ContentChildren, EventEmitter, Input,
-  OnDestroy, OnInit, Output, QueryList, TemplateRef, ViewChild, ViewEncapsulation
+  OnDestroy, OnInit, Output, QueryList, TemplateRef, ViewChild
 } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, SortDirection } from '@angular/material/sort';
@@ -18,7 +18,6 @@ export interface TableColumn {
   selector: 'custom-table',
   templateUrl: './custom-table.component.html',
   styleUrls: ['./custom-table.component.scss'],
-  encapsulation: ViewEncapsulation.None
 })
 
 export class CustomTableComponent<T> implements OnInit, AfterViewInit, OnDestroy {

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.component.ts
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.component.ts
@@ -1,13 +1,18 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import {
-  AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input,
-  OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation
+  AfterViewInit, Component, ContentChildren, EventEmitter, Input,
+  OnDestroy, OnInit, Output, QueryList, TemplateRef, ViewChild, ViewEncapsulation
 } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, SortDirection } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { Observable, Subject, takeUntil } from 'rxjs';
-import { CustomTableAbstractDirective } from './custom-table-abstract.directive';
+import { TableColumnDirective } from './custom-table-abstract.directive';
+
+export interface TableColumn {
+  key: string;
+  header?: string;
+}
 
 @Component({
   selector: 'custom-table',
@@ -16,14 +21,15 @@ import { CustomTableAbstractDirective } from './custom-table-abstract.directive'
   encapsulation: ViewEncapsulation.None
 })
 
-export class CustomTableComponent<T> extends CustomTableAbstractDirective<T> implements OnInit, AfterViewInit, OnDestroy {
+export class CustomTableComponent<T> implements OnInit, AfterViewInit, OnDestroy {
 
   data: MatTableDataSource<T> = new MatTableDataSource<T>([]);
   private selection = new SelectionModel<{}>(true, []); // store selection data
 
   /** Definitions: data */
-  
+
   @Input() dataSource!: Observable<Array<T>>;
+  @Input() columns: Array<TableColumn> = [];
 
   /** Pagination */
 
@@ -50,26 +56,50 @@ export class CustomTableComponent<T> extends CustomTableAbstractDirective<T> imp
   @Output() action = new EventEmitter();
   @Output() selectedRows = new EventEmitter();
 
-  private destroy$ = new Subject<void>();
+  private _destroyed$ = new Subject<boolean>();
 
-  constructor(private readonly cdr: ChangeDetectorRef) {
-    super([]);
+  /** construct columns definitions  */
+
+  @ContentChildren(TableColumnDirective) private columnDefs: QueryList<TableColumnDirective>;
+  get columnTemplates(): { [key: string]: TemplateRef<any> } {
+    if (this.columnDefs !== null) {
+      const columnTemplates: { [key: string]: TemplateRef<any> } = {};
+      for (const column of this.columnDefs.toArray()) {
+        columnTemplates[column.columnName] = column.columnTemplate;
+      }
+      return columnTemplates;
+    }
+    return {};
   }
+  get displayColumns(): Array<string> {
+    return this.columns.map(({ key }) => key);
+  }
+
+  constructor() { }
 
   ngOnInit(): void {
     this.selection = new SelectionModel<{}>(this.allowMultiSelect, []);
   }
 
   ngAfterViewInit(): void {
+    this.configColumns();
+    this.getDataSource();
+  }
+
+  private getDataSource(): void {
     this.dataSource
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(this._destroyed$))
       .subscribe((response: Array<T>) => {
         this.data = new MatTableDataSource<T>(response);
         this.data.sort = this.sort;
         this.data.paginator = this.pageable ? this.paginator : null;
       });
+  }
 
-    this.cdr.detectChanges();
+  private configColumns(): void {
+    for (const column of this.columnDefs.toArray()) {
+      this.columnTemplates[column.columnName] = column.columnTemplate;
+    }
   }
 
   /**
@@ -96,7 +126,7 @@ export class CustomTableComponent<T> extends CustomTableAbstractDirective<T> imp
   }
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+    this._destroyed$.next(true);
+    this._destroyed$.complete();
   }
 }

--- a/projects/mia-lib/src/lib/components/custom-table/custom-table.module.ts
+++ b/projects/mia-lib/src/lib/components/custom-table/custom-table.module.ts
@@ -5,10 +5,11 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
+import { TableColumnDirective } from './custom-table-abstract.directive';
 import { CustomTableComponent } from './custom-table.component';
 
 @NgModule({
-  declarations: [CustomTableComponent],
+  declarations: [CustomTableComponent, TableColumnDirective],
   imports: [
     CommonModule,
     MatSortModule,
@@ -17,6 +18,6 @@ import { CustomTableComponent } from './custom-table.component';
     MatPaginatorModule,
     MatProgressSpinnerModule
   ],
-  exports: [CustomTableComponent],
+  exports: [CustomTableComponent, TableColumnDirective],
 })
 export class CustomTableModule { }

--- a/src/app/components-ui/table/crud-users/components/list/list.component.html
+++ b/src/app/components-ui/table/crud-users/components/list/list.component.html
@@ -5,7 +5,7 @@
 <ng-template #noError>
   <custom-table
     [dataSource]="users$"
-    [columns]="['id', 'name', 'email']"
+    [columns]="columns"
     [defaultSortColumn]="'name'"
   >
     <div header class="d-flex ai-baseline jc-between mb-1">
@@ -14,5 +14,11 @@
         Create User
       </button>
     </div>
+
+    <custom-column columnName="email">
+      <ng-template let-user>
+        {{ user.email | lowercase }}
+      </ng-template>
+    </custom-column>
   </custom-table>
 </ng-template>

--- a/src/app/components-ui/table/crud-users/components/list/list.component.ts
+++ b/src/app/components-ui/table/crud-users/components/list/list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { TableColumn } from '@lib/components/custom-table/custom-table.component';
 import { IUser } from '@lib/models/user';
 import { UsersService } from '@lib/services/users/users.service';
 import { catchError, Observable, Subject, throwError } from 'rxjs';
@@ -13,6 +14,12 @@ type User = Partial<IUser>;
 export class ListComponent implements OnInit {
   users$: Observable<Array<User>>;
   errorMessage$ = new Subject<string>();
+
+  columns: Array<TableColumn> = [
+    { key: 'id' },
+    { key: 'name' },
+    { key: 'email' },
+  ];
 
   constructor(private readonly userService: UsersService) { }
 


### PR DESCRIPTION
#### Remove  ♻
1. CustomTableAbstractDirective

#### Refactor⚒
1. refactor (`custom-table`): use template directive instead.
- key property should be mapped with item property.
- if we do not define a header, we will use key property to set the column header name.
- when we want to override any column, use the `custom-column` tag.
2. update (`user.list`): use `custom-table` with some new properties.
3. style (`custom-table`): remove view encapsulation and override with new class.