### PR TITLE
v.1.1.7/bugfix_1.0

### DIFF
--- a/projects/mia-lib/src/lib/services/users/user-details.service.spec.ts
+++ b/projects/mia-lib/src/lib/services/users/user-details.service.spec.ts
@@ -1,0 +1,22 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { UserDetailsService } from './user-details.service';
+
+describe('UserDetailsService', () => {
+  let service: UserDetailsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule
+      ]
+    });
+    service = TestBed.inject(UserDetailsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/mia-lib/src/lib/services/users/user-details.service.ts
+++ b/projects/mia-lib/src/lib/services/users/user-details.service.ts
@@ -1,0 +1,65 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, finalize, map, Observable, shareReplay, Subject, takeUntil, tap } from 'rxjs';
+import { ActivatedParamsService } from '../activated-params/activated-params.service';
+import { User, users_endpoint, user_id_endpoint } from './user-service.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserDetailsService implements OnDestroy {
+  private _user$ = new BehaviorSubject<User>(null);
+  readonly currentUser$ = this._user$.asObservable();
+
+  private _loading$ = new BehaviorSubject<boolean>(false);
+  readonly loading$ = this._loading$.asObservable();
+
+  private _destroyed$ = new Subject<boolean>();
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly route: ActivatedParamsService
+  ) {
+    this.getUserByRouteParams();
+  }
+
+  private getUserByRouteParams(): void {
+    this.route.paramsMap$
+      .pipe(takeUntil(this._destroyed$))
+      .subscribe({
+        next: ({ user_id }) => {
+          if (!isNaN(+user_id)) {
+            this._loading$.next(true);
+
+            this.byId(+user_id)
+              .pipe(finalize(() => this._loading$.next(false)))
+              .subscribe({
+                next: (response: User) => this._user$.next(response)
+              });
+          }
+        }
+      });
+  }
+
+  byId(id: number): Observable<User> {
+    return this.http.get<Required<User>>(user_id_endpoint(id)).pipe(
+      map(({ id, name, email }) => <User>{ id, name, email, hobbies: ['coding', 'basketball'] }),
+      shareReplay()
+    );
+  }
+
+  create(user: User): Observable<User> {
+    return this.http.post<Required<User>>(users_endpoint, user);
+  }
+
+  update(user: User): Observable<User> {
+    return this.http.put<Required<User>>(user_id_endpoint(user.id), user).pipe(
+      tap((data: User) => this._user$.next(data))
+    );
+  }
+
+  ngOnDestroy(): void {
+    this._destroyed$.next(true);
+    this._destroyed$.complete();
+  }
+}

--- a/projects/mia-lib/src/lib/services/users/user-service.model.ts
+++ b/projects/mia-lib/src/lib/services/users/user-service.model.ts
@@ -1,0 +1,8 @@
+import { environment } from '@env/environment';
+import { IUser } from '@lib/models/user';
+
+type User = Partial<IUser>;
+const users_endpoint: string = environment.jsonPlaceHolderUrl + 'users/';
+const user_id_endpoint = (id: number | string): string => users_endpoint + `${id}`;
+
+export { User, users_endpoint, user_id_endpoint };

--- a/projects/mia-lib/src/lib/services/users/users.service.ts
+++ b/projects/mia-lib/src/lib/services/users/users.service.ts
@@ -1,79 +1,26 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { environment } from '@env/environment';
-import { IUser } from '@lib/models/user';
-import { BehaviorSubject, finalize, map, Observable, shareReplay, tap } from 'rxjs';
-import { ActivatedParamsService } from '../activated-params/activated-params.service';
-import { BaseService } from '../base/base.service';
-
-export type User = Partial<IUser>;
+import { map, Observable, shareReplay } from 'rxjs';
+import { User, users_endpoint, user_id_endpoint } from './user-service.model';
 
 @Injectable({
   providedIn: 'root'
 })
 
-export class UsersService implements BaseService<User> {
-
-  private _user$ = new BehaviorSubject<User>(null);
-  readonly currentUser$ = this._user$.asObservable();
-
-  private _loading$ = new BehaviorSubject<boolean>(false);
-  readonly loading$ = this._loading$.asObservable();
+export class UsersService {
 
   constructor(
     private readonly http: HttpClient,
-    private readonly route: ActivatedParamsService
-  ) {
-    this.getUserByRouteParams();
-  }
-
-  private getUserByRouteParams(): void {
-    this.route.paramsMap$.subscribe({
-      next: ({ user_id }) => {
-        this._loading$.next(true);
-
-        this.byId(+user_id)
-          .pipe(finalize(() => this._loading$.next(false)))
-          .subscribe({
-            next: (response: User) => this._user$.next(response)
-          });
-      }
-    });
-  }
+  ) { }
 
   all(): Observable<Array<User>> {
-    return this.http.get<Array<Required<User>>>(this.endpoint).pipe(
+    return this.http.get<Array<Required<User>>>(users_endpoint).pipe(
       map(data => data.map(({ id, name, email }) => <User>{ id, name, email })),
-      shareReplay()
-    );
-  }
-
-  byId(id: number): Observable<User> {
-    return this.http.get<Required<User>>(this.urlById(id)).pipe(
-      map(({ id, name, email }) => <User>{ id, name, email, hobbies: ['coding', 'basketball'] }),
-      shareReplay()
-    );
-  }
-
-  create(user: User): Observable<User> {
-    return this.http.post<Required<User>>(this.endpoint, user);
-  }
-
-  update(user: User): Observable<User> {
-    return this.http.put<Required<User>>(this.urlById(user.id), user).pipe(
-      tap((data: User) => this._user$.next(data))
+      shareReplay(1)
     );
   }
 
   delete(id: number): Observable<User> {
-    return this.http.delete<Required<User>>(this.urlById(id));
-  }
-
-  private urlById(id: number | string): string {
-    return this.endpoint + `${id}`;
-  }
-
-  private get endpoint(): string {
-    return environment.jsonPlaceHolderUrl + 'users/';
+    return this.http.delete<Required<User>>(user_id_endpoint(id));
   }
 }

--- a/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.html
@@ -1,6 +1,6 @@
 <ng-container>
-  <ng-container *ngIf="user">
-    <span class="text-secondary">{{ user.name }} / </span>
+  <ng-container *ngIf="name$ | async as name">
+    <span class="text-secondary">{{ name }} / </span>
   </ng-container>
   <ng-content></ng-content>
 </ng-container>

--- a/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,17 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 
 describe('BreadcrumbsComponent', () => {
   let component: BreadcrumbsComponent;
   let fixture: ComponentFixture<BreadcrumbsComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ BreadcrumbsComponent ]
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [BreadcrumbsComponent],
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+      ],
+      providers: [UserDetailsService]
     })
-    .compileComponents();
-  });
+      .compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbsComponent);

--- a/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/components-ui/table/crud-users/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,10 +1,15 @@
-import { Component, Input } from '@angular/core';
-import { User } from '@lib/services/users/users.service';
+import { Component } from '@angular/core';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
+import { Observable, pluck } from 'rxjs';
 
 @Component({
   selector: 'user-breadcrumbs',
   templateUrl: './breadcrumbs.component.html'
 })
 export class BreadcrumbsComponent {
-  @Input() user: User;
+  name$: Observable<string> = this.service.currentUser$.pipe(
+    pluck('name'),
+  ) as Observable<string>;
+
+  constructor(private readonly service: UserDetailsService) { }
 }

--- a/src/app/components-ui/table/crud-users/components/create/create.component.html
+++ b/src/app/components-ui/table/crud-users/components/create/create.component.html
@@ -11,7 +11,7 @@
       mat-flat-button
       color="primary"
       (click)="onCreate()"
-      [disabled]="!isValid"
+      [disabled]="saving || !isValid"
     >
       Save
     </button>

--- a/src/app/components-ui/table/crud-users/components/create/create.component.spec.ts
+++ b/src/app/components-ui/table/crud-users/components/create/create.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterTestingModule } from '@angular/router/testing';
-import { UsersService } from '@lib/services/users/users.service';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
 import { of, throwError } from 'rxjs';
 import { CreateComponent } from './create.component';
 
@@ -33,7 +33,7 @@ describe('CreateComponent', () => {
       ],
       providers: [
         {
-          provide: UsersService,
+          provide: UserDetailsService,
           useValue: service
         }
       ]

--- a/src/app/components-ui/table/crud-users/components/create/create.component.ts
+++ b/src/app/components-ui/table/crud-users/components/create/create.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { SnackbarService } from '@lib/services/snackbar/snackbar.service';
-import { User, UsersService } from '@lib/services/users/users.service';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
+import { User } from '@lib/services/users/user-service.model';
 import { finalize } from 'rxjs';
 
 @Component({
@@ -17,7 +18,7 @@ export class CreateComponent {
   constructor(
     private readonly router: Router,
     private readonly snackbar: SnackbarService,
-    private readonly userService: UsersService
+    private readonly service: UserDetailsService,
   ) { }
 
   onFormChanged(data: User): void {
@@ -26,7 +27,7 @@ export class CreateComponent {
 
   onCreate(): void {
     this.saving = true;
-    this.userService.create(this.user)
+    this.service.create(this.user)
       .pipe(finalize(() => this.saving = false))
       .subscribe({
         next: () => this.snackbar.success('The user has been created.'),

--- a/src/app/components-ui/table/crud-users/components/details/details.component.html
+++ b/src/app/components-ui/table/crud-users/components/details/details.component.html
@@ -7,7 +7,7 @@
   ></custom-input>
   <custom-input
     label="Email"
-    type="text"
+    type="email"
     [required]="true"
     formControlName="email"
   ></custom-input>

--- a/src/app/components-ui/table/crud-users/components/details/details.component.ts
+++ b/src/app/components-ui/table/crud-users/components/details/details.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } 
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { NgChanges } from '@lib/helpers/mark-function-properties';
-import { User } from '@lib/services/users/users.service';
+import { User } from '@lib/services/users/user-service.model';
 import { hasDuplicates } from '@lib/utils/array-utils';
 import { Regex } from '@lib/utils/form-validation';
 import { debounceTime, distinctUntilChanged, Subject, takeUntil } from 'rxjs';

--- a/src/app/components-ui/table/crud-users/components/list/list.component.spec.ts
+++ b/src/app/components-ui/table/crud-users/components/list/list.component.spec.ts
@@ -9,7 +9,8 @@ import { ConfirmDialogModule } from '@lib/components/confirm-dialog/confirm-dial
 import { CustomButtonModule } from '@lib/components/custom-button/custom-button.module';
 import { CustomTableModule } from '@lib/components/custom-table/custom-table.module';
 import { SnackbarService } from '@lib/services/snackbar/snackbar.service';
-import { User, UsersService } from '@lib/services/users/users.service';
+import { User } from '@lib/services/users/user-service.model';
+import { UsersService } from '@lib/services/users/users.service';
 import { of, throwError } from 'rxjs';
 import { ListComponent } from './list.component';
 

--- a/src/app/components-ui/table/crud-users/components/list/list.component.ts
+++ b/src/app/components-ui/table/crud-users/components/list/list.component.ts
@@ -3,7 +3,8 @@ import { MatDialog } from '@angular/material/dialog';
 import { ConfirmDialogComponent } from '@lib/components/confirm-dialog/confirm-dialog.component';
 import { TableColumn } from '@lib/components/custom-table/custom-table.component';
 import { SnackbarService } from '@lib/services/snackbar/snackbar.service';
-import { User, UsersService } from '@lib/services/users/users.service';
+import { User } from '@lib/services/users/user-service.model';
+import { UsersService } from '@lib/services/users/users.service';
 import { catchError, filter, finalize, map, Observable, of, Subject, switchMap } from 'rxjs';
 
 @Component({

--- a/src/app/components-ui/table/crud-users/components/update/update.component.html
+++ b/src/app/components-ui/table/crud-users/components/update/update.component.html
@@ -14,7 +14,7 @@
   <ng-template #details>
     <ng-container *ngIf="user$ | async as user">
       <div class="d-flex jc-between ai-center">
-        <user-breadcrumbs [user]="user">Details</user-breadcrumbs>
+        <user-breadcrumbs>Details</user-breadcrumbs>
         <button
           mat-flat-button
           color="primary"

--- a/src/app/components-ui/table/crud-users/components/update/update.component.spec.ts
+++ b/src/app/components-ui/table/crud-users/components/update/update.component.spec.ts
@@ -6,7 +6,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SnackbarService } from '@lib/services/snackbar/snackbar.service';
-import { User, UsersService } from '@lib/services/users/users.service';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
+import { User } from '@lib/services/users/user-service.model';
 import { combineLatest, of, throwError } from 'rxjs';
 import { BreadcrumbsModule } from '../breadcrumbs/breadcrumbs.module';
 import { DetailsModule } from '../details/details.module';
@@ -50,7 +51,7 @@ describe('UpdateComponent', () => {
       ],
       providers: [
         {
-          provide: UsersService,
+          provide: UserDetailsService,
           useValue: service
         },
         {

--- a/src/app/components-ui/table/crud-users/components/update/update.component.ts
+++ b/src/app/components-ui/table/crud-users/components/update/update.component.ts
@@ -3,8 +3,9 @@ import { FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { DeactivateComponent } from '@lib/models/base-form-component';
 import { SnackbarService } from '@lib/services/snackbar/snackbar.service';
-import { User, UsersService } from '@lib/services/users/users.service';
-import { combineLatest, filter, finalize, map, Observable, startWith, Subject, takeUntil, tap } from 'rxjs';
+import { UserDetailsService } from '@lib/services/users/user-details.service';
+import { User } from '@lib/services/users/user-service.model';
+import { combineLatest, filter, finalize, map, Observable, startWith, Subject, take, takeUntil, tap } from 'rxjs';
 
 @Component({
   selector: 'update-user',
@@ -20,20 +21,19 @@ export class UpdateComponent implements OnInit, OnDestroy, DeactivateComponent {
   saving = false;
   hasChanged = false;
 
-  destroy$ = new Subject<boolean>();
-  loading$: Observable<boolean> = this.userService.loading$;
+  destroyed$ = new Subject<boolean>();
+  readonly loading$: Observable<boolean> = this.service.loading$;
 
   constructor(
     private readonly router: Router,
-    private readonly userService: UsersService,
     private readonly snackbar: SnackbarService,
+    private readonly service: UserDetailsService,
   ) { }
 
   ngOnInit(): void {
-    this.user$ = this.userService.currentUser$.pipe(
+    this.user$ = this.service.currentUser$.pipe(
       filter(data => data !== null),
-      tap(({ id }) => this.user_id = id as number),
-      takeUntil(this.destroy$)
+      tap(({ id }) => this.user_id = id as number)
     );
     this.watchForFormChanged();
   }
@@ -45,7 +45,8 @@ export class UpdateComponent implements OnInit, OnDestroy, DeactivateComponent {
     ])
       .pipe(
         map(([prev, next]) => JSON.stringify(prev) !== JSON.stringify(next)),
-        startWith(false)
+        startWith(false),
+        takeUntil(this.destroyed$)
       )
       .subscribe((changed: boolean) => this.hasChanged = changed);
   }
@@ -60,8 +61,11 @@ export class UpdateComponent implements OnInit, OnDestroy, DeactivateComponent {
 
   saveChanges(url?: string): void {
     this.saving = true;
-    this.userService.update({ id: this.user_id, ...this.user.value })
-      .pipe(finalize(() => this.saving = false))
+    this.service.update({ id: this.user_id, ...this.user.value })
+      .pipe(
+        take(1),
+        finalize(() => this.saving = false)
+      )
       .subscribe({
         next: () => this.snackbar.success('The user has been updated.'),
         error: ({ message }) => this.snackbar.error(message),
@@ -70,7 +74,7 @@ export class UpdateComponent implements OnInit, OnDestroy, DeactivateComponent {
   }
 
   ngOnDestroy(): void {
-    this.destroy$.next(true);
-    this.destroy$.complete();
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
   }
 }

--- a/src/app/interceptors/monitor.interceptor.ts
+++ b/src/app/interceptors/monitor.interceptor.ts
@@ -41,6 +41,6 @@ export class MonitorInterceptor implements HttpInterceptor {
 
   private logRequestTime(startTime: number, url: string, method: string): void {
     const requestDuration = `${performance.now() - startTime}`;
-    this.logger.log(`HTTP.${method} ${url} - ${requestDuration} ms`);
+    this.logger.log(`${method} ${url} - ${requestDuration} ms`);
   }
 }


### PR DESCRIPTION
#### Update ⚒
1. `monitor-interceptor` : remove HTTP keyword.

#### Something New  ✨
1. `user.service` : split into two diff services (get all and details)
-- purpose: reusable, scalable - (fetch current user data for both components: breadcrumbs and details page)

> Code clean-up, fixed backlogs